### PR TITLE
Print debugging info to syslog

### DIFF
--- a/wait-for-interfaces.sh
+++ b/wait-for-interfaces.sh
@@ -5,11 +5,14 @@ INTERFACES=("ib0")
 
 for IFACE in "${INTERFACES[@]}"; do
     COUNTER=0
-    while ! nmcli device show "$IFACE" | grep -q "(connected)"; do
+    while ! nmcli --get-values GENERAL.STATE device show "$IFACE" | grep -q "(connected)"; do
+        # Print debugging info to syslog
+        echo -n "Waiting for interface $IFACE to come online:"
+        nmcli --get-values GENERAL.STATE device show "$IFACE"
         sleep 1
         COUNTER=$((COUNTER + 1))
         if [ "$COUNTER" -ge "$TIMEOUT" ]; then
-            echo "Interface $IFACE did not come online within timeout"
+            echo "ERROR: Interface $IFACE did not come online within timeout=$TIMEOUT"
             exit 1
         fi
     done


### PR DESCRIPTION
I suggest to add print debugging info to syslog so that we can follow the ib0 network status during boot