### PR TITLE
Test for existence of $IFACE

### DIFF
--- a/wait-for-interfaces.sh
+++ b/wait-for-interfaces.sh
@@ -3,23 +3,27 @@
 TIMEOUT=300
 INTERFACES=("ib0")
 
-echo "Wait for network devices, available connections are:"
-nmcli connection show 
-
 for IFACE in "${INTERFACES[@]}"; do
-    COUNTER=0
-    status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
-    until echo "$status" | grep -q "(connected)"
-    do
-        COUNTER=$((COUNTER + 1))
-        if [ "$COUNTER" -gt "$TIMEOUT" ]; then
-            echo "ERROR: Interface $IFACE did not come online within timeout=$TIMEOUT"
-            exit 1
-        fi
-        sleep 1
-	status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
-        echo "Waiting for interface $IFACE to come online: $status"
-    done
+    if `nmcli connection show | awk '{print $NF}' | grep -q $IFACE`
+    then
+        echo "Wait for network interface $IFACE to come online"
+        COUNTER=0
+        status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
+        until echo "$status" | grep -q "(connected)"
+        do
+            COUNTER=$((COUNTER + 1))
+            if [ "$COUNTER" -gt "$TIMEOUT" ]; then
+                echo "ERROR: Interface $IFACE did not come online within timeout=$TIMEOUT"
+                exit 1
+            fi
+            sleep 1
+	    status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
+            echo "Waiting for interface $IFACE to come online: $status"
+        done
+    else
+        echo "Notice: Interface $IFACE not found, available connections are:"
+        nmcli connection show 
+    fi
 done
 
 exit 0

--- a/wait-for-interfaces.sh
+++ b/wait-for-interfaces.sh
@@ -3,18 +3,22 @@
 TIMEOUT=300
 INTERFACES=("ib0")
 
+echo "Wait for network devices, available connections are:"
+nmcli connection show 
+
 for IFACE in "${INTERFACES[@]}"; do
     COUNTER=0
-    while ! nmcli --get-values GENERAL.STATE device show "$IFACE" | grep -q "(connected)"; do
-        # Print debugging info to syslog
-        echo -n "Waiting for interface $IFACE to come online:"
-        nmcli --get-values GENERAL.STATE device show "$IFACE"
-        sleep 1
+    status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
+    until echo "$status" | grep -q "(connected)"
+    do
         COUNTER=$((COUNTER + 1))
-        if [ "$COUNTER" -ge "$TIMEOUT" ]; then
+        if [ "$COUNTER" -gt "$TIMEOUT" ]; then
             echo "ERROR: Interface $IFACE did not come online within timeout=$TIMEOUT"
             exit 1
         fi
+        sleep 1
+	status="`nmcli --get-values GENERAL.STATE device show $IFACE`"
+        echo "Waiting for interface $IFACE to come online: $status"
     done
 done
 


### PR DESCRIPTION
I added a test for the existence of $IFACE so that the script will work without errors on nodes that don't have devices in the INTERFACES list.
Also the output of nmcli is now stored in a "status" variable so it can be used in print statements.